### PR TITLE
Grab native crash report

### DIFF
--- a/test-app/src/androidTest/java/com/example/boxup/bucks/EdgeCases.java
+++ b/test-app/src/androidTest/java/com/example/boxup/bucks/EdgeCases.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 public final class EdgeCases {
+
   private static final int SIGABRT = 6; // http://man7.org/linux/man-pages/man7/signal.7.html
 
   @Test @Ignore("Message!") public void ignored() {

--- a/test-app/src/androidTest/java/com/example/boxup/bucks/EdgeCases.java
+++ b/test-app/src/androidTest/java/com/example/boxup/bucks/EdgeCases.java
@@ -1,5 +1,7 @@
 package com.example.boxup.bucks;
 
+import android.util.Log;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -7,11 +9,23 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 public final class EdgeCases {
+  private static final int SIGABRT = 6; // http://man7.org/linux/man-pages/man7/signal.7.html
+
   @Test @Ignore("Message!") public void ignored() {
     fail();
   }
 
   @Test public void assumptionFailure() {
     assumeTrue(false);
+  }
+
+  @Test @Ignore("It crashes JVM, intended only for local test runs.") public void nativeCrash() {
+    Log.w("nativeCrash", "kill myself");
+    android.os.Process.sendSignal(android.os.Process.myTid(), SIGABRT);
+    try {
+      Thread.sleep(Long.MAX_VALUE); // Block thread until signal become delivered
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }


### PR DESCRIPTION
***Change***
Now `SpoonDeviceLogger` is also looking for `debuggerd` messages too.

***Test plan***
Un-ignore `nativeCrash()` test case, run
```
$ ./gradlew spoonAndroidTest
```
and ensure that log contains crash trace.